### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file. The format is b
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/adrien-jeser-doctolib/rust-rapport/compare/v0.1.2...v0.1.3) - 2026-04-23
+
+### Other
+
+- exempt rust-rapport from self-vet (first-party, not external dep)
+- pin cargo-vet to 0.10.0 to match local toolchain (fixes imports.lock formatting drift)
+
 ## [0.1.2](https://github.com/adrien-jeser-doctolib/rust-rapport/compare/v0.1.1...v0.1.2) - 2026-04-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rust-rapport"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-rapport"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.85"
 description = "Formats cargo clippy JSON output for GitHub Actions (step summary, PR annotations, human-readable)."


### PR DESCRIPTION



## 🤖 New release

* `rust-rapport`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/adrien-jeser-doctolib/rust-rapport/compare/v0.1.2...v0.1.3) - 2026-04-23

### Other

- exempt rust-rapport from self-vet (first-party, not external dep)
- pin cargo-vet to 0.10.0 to match local toolchain (fixes imports.lock formatting drift)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).