### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file. The format is b
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/adrien-jeser-doctolib/rust-rapport/compare/v0.1.8...v0.2.0) - 2026-04-23
+
+### Added
+
+- add `github` mode that handles summary + annotations + exit code
+
 ## [0.1.8](https://github.com/adrien-jeser-doctolib/rust-rapport/compare/v0.1.7...v0.1.8) - 2026-04-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rust-rapport"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-rapport"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Formats cargo clippy JSON output for GitHub Actions (step summary, PR annotations, human-readable)."


### PR DESCRIPTION



## 🤖 New release

* `rust-rapport`: 0.1.8 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `rust-rapport` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Mode::GithubSummary 0 -> 1 in /tmp/.tmpJs2QzC/rust-rapport/src/lib.rs:45
  variant Mode::GithubPrAnnotation 1 -> 2 in /tmp/.tmpJs2QzC/rust-rapport/src/lib.rs:47
  variant Mode::Human 2 -> 3 in /tmp/.tmpJs2QzC/rust-rapport/src/lib.rs:49

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  Mode::GithubSummary moved from position 1 to 2, in /tmp/.tmpJs2QzC/rust-rapport/src/lib.rs:45
  Mode::GithubPrAnnotation moved from position 2 to 3, in /tmp/.tmpJs2QzC/rust-rapport/src/lib.rs:47
  Mode::Human moved from position 3 to 4, in /tmp/.tmpJs2QzC/rust-rapport/src/lib.rs:49
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/adrien-jeser-doctolib/rust-rapport/compare/v0.1.8...v0.2.0) - 2026-04-23

### Added

- add `github` mode that handles summary + annotations + exit code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).